### PR TITLE
Add missing ruby comment syntax and more ruby extensions

### DIFF
--- a/syntax_files/ruby.yaml
+++ b/syntax_files/ruby.yaml
@@ -1,7 +1,7 @@
 filetype: ruby
 
 detect: 
-    filename: "\\.rb$|\\.gemspec$|Gemfile|config.ru|Rakefile|Capfile|Vagrantfile"
+    filename: "\\.rb$|\\.ru|\\.rbx|\\.rake|\\.gemspec$|Gemfile|Rakefile|Capfile|Vagrantfile"
     header: "^#!.*/(env +)?ruby( |$)"
 
 rules:
@@ -16,6 +16,10 @@ rules:
     - special: "#\\{[^}]*\\}"
     - constant.string: "'([^']|(\\\\'))*'|%[qw]\\{[^}]*\\}|%[qw]\\([^)]*\\)|%[qw]<[^>]*>|%[qw]\\[[^]]*\\]|%[qw]\\$[^$]*\\$|%[qw]\\^[^^]*\\^|%[qw]![^!]*!"
     - comment: "#[^{].*$|#$"
+    - comment:
+        start: "=begin"
+        end: "=end"
+        rules: []
     - comment.bright: "##[^{].*$|##$"
     - constant.macro:
         start: "<<-?'?EOT'?"


### PR DESCRIPTION
`.ru` extension can be any file.

Also, there is some conflicts with `crystal` language when it comes to `config.ru`.