### PR TITLE
Ignore case of conditional flags in fish

### DIFF
--- a/syntax_files/fish.yaml
+++ b/syntax_files/fish.yaml
@@ -22,8 +22,8 @@ rules:
     - type: "\\b(base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|(sha1|sha224|sha256|sha384|sha512)sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|time|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b"
 
       # Conditional flags
-    - statement: "--[a-z-]+"
-    - statement: "\\ -[a-z]+"
+    - statement: "(?i)--[a-z-]+"
+    - statement: "(?i)\\ -[a-z]+"
 
     - identifier: "(?i)\\$\\{?[0-9A-Z_!@#$*?-]+\\}?"
 


### PR DESCRIPTION
This allows for uppercase characters in conditional flags in `.fish` files.

I'd suggest this change, because some programs use uppercase characters in such positions. For example [hugo](https://gohugo.io/) has a `--baseURL` option and rusts [clap](https://crates.io/crates/clap) library for command line parameter parsing by default provides `-V` as shorthand for `--version`.