### PR TITLE
Updated to include embedded syntax files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ func main() {
 }
 ```
 
+## Automatically Detecting Filetypes
+
 If you would like to automatically detect the filetype of a file based on the filename, and have the appropriate definition returned,
 you can use the `DetectFiletype` function:
 
@@ -123,5 +125,48 @@ var defs []*highlight.Def
 def := highlight.DetectFiletype(defs, filename, firstLine)
 fmt.Println("Filetype is", def.FileType)
 ```
+
+## Embedded Syntax Files
+
+You can embed the syntax files directly in your program by using the `AllDefs` function. For example,
+
+```go
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "strings"
+
+    "github.com/zyedidia/highlight"
+)
+
+func main() {
+    // Load all the syntax files
+    defs,err := highlight.AllDefs()
+    if err != nil {
+        panic(err)
+    }
+    // Detect filetype of a file
+    def := highlight.DetectFiletype(defs, filename, firstLine)
+    if def == nil {
+        // ....
+    } else {
+        // ....
+    }
+}
+```
+
+If you only want to read specific syntax files, you can pass the filetypes as an argument, for example:
+
+```go
+    // Load specific filetypes
+    defs,err := highlight.AllDefs("c", "c++", "python", "go")
+    if err != nil {
+        panic(err)
+    }
+```
+
+# Examples
 
 For a full example, see the [`syncat`](./examples) example which acts like cat but will syntax highlight the output (if highlight recognizes the filetype).

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,56 @@
+package highlight
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+//go:embed syntax_files
+var syntaxFiles embed.FS
+
+// AllDefs returns all the definitions in the embedded file system,
+// filtering for named definitions if argument is provided
+func AllDefs(fileType ...string) ([]*Def, error) {
+	all, err := syntaxFiles.ReadDir("syntax_files")
+	if err != nil {
+		panic(err)
+	}
+	results := make([]*Def, 0, len(all))
+	for _, file := range all {
+		if file.IsDir() {
+			continue
+		}
+		if filepath.Ext(file.Name()) != ".yaml" {
+			continue
+		}
+		data, err := fs.ReadFile(syntaxFiles, filepath.Join("syntax_files", file.Name()))
+		if err != nil {
+			return nil, err
+		}
+		def, err := ParseDef(data)
+		if err != nil {
+			// Error handling
+			return nil, fmt.Errorf("%v: %w", file.Name(), err)
+		}
+		if len(fileType) == 0 || sliceContains(fileType, def.FileType) {
+			results = append(results, def)
+		}
+	}
+
+	// Call ResolveIncludes
+	ResolveIncludes(results)
+
+	// Return all definitions
+	return results, nil
+}
+
+func sliceContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,34 @@
+package highlight_test
+
+import (
+	"testing"
+
+	// Namespace imports
+	. "github.com/zyedidia/highlight"
+)
+
+func Test_Embed_001(t *testing.T) {
+	defs, err := AllDefs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) == 0 {
+		t.Error("Expected non-zero defs array")
+	}
+	for n, def := range defs {
+		t.Log(n, "=>", def)
+	}
+}
+
+func Test_Embed_002(t *testing.T) {
+	defs, err := AllDefs("yum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for n, def := range defs {
+		if def.FileType != "yum" {
+			t.Error("Expected FileType to be yum")
+		}
+		t.Log(n, "=>", def)
+	}
+}

--- a/examples/embed/embed.go
+++ b/examples/embed/embed.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/zyedidia/highlight"
+)
+
+func main() {
+	if len(os.Args) <= 1 {
+		fmt.Fprintf(os.Stderr, "Error: No input file\n")
+		os.Exit(-1)
+	}
+
+	defs, err := highlight.AllDefs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(-1)
+	}
+
+	fileSrc, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(-1)
+	}
+
+	def := highlight.DetectFiletype(defs, os.Args[1], bytes.Split(fileSrc, []byte("\n"))[0])
+	if def == nil {
+		fmt.Println(string(fileSrc))
+		os.Exit(0)
+	}
+
+	h := highlight.NewHighlighter(def)
+	matches := h.HighlightString(string(fileSrc))
+	lines := strings.Split(string(fileSrc), "\n")
+	for lineN, l := range lines {
+		colN := 0
+		for _, c := range l {
+			if group, ok := matches[lineN][colN]; ok {
+				// There are more possible groups available than just these ones
+				if group == highlight.Groups["statement"] {
+					color.Set(color.FgGreen)
+				} else if group == highlight.Groups["identifier"] {
+					color.Set(color.FgBlue)
+				} else if group == highlight.Groups["preproc"] {
+					color.Set(color.FgHiRed)
+				} else if group == highlight.Groups["special"] {
+					color.Set(color.FgRed)
+				} else if group == highlight.Groups["constant.string"] {
+					color.Set(color.FgCyan)
+				} else if group == highlight.Groups["constant"] {
+					color.Set(color.FgCyan)
+				} else if group == highlight.Groups["constant.specialChar"] {
+					color.Set(color.FgHiMagenta)
+				} else if group == highlight.Groups["type"] {
+					color.Set(color.FgYellow)
+				} else if group == highlight.Groups["constant.number"] {
+					color.Set(color.FgCyan)
+				} else if group == highlight.Groups["comment"] {
+					color.Set(color.FgHiGreen)
+				} else {
+					color.Unset()
+				}
+			}
+			fmt.Print(string(c))
+			colN++
+		}
+		if group, ok := matches[lineN][colN]; ok {
+			if group == highlight.Groups["default"] || group == highlight.Groups[""] {
+				color.Unset()
+			}
+		}
+
+		fmt.Print("\n")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/zyedidia/highlight
+
+go 1.17
+
+require (
+	github.com/fatih/color v1.13.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.9 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
I added some code to embed the syntax files, and a new method `AllDefs` which read syntax file definitions from the embedded syntax files. Also added an example, a test and a `go.mod` file plus updated the README.

